### PR TITLE
Reimplementation w/ pyg

### DIFF
--- a/hypgs/models/hsn_pyg.py
+++ b/hypgs/models/hsn_pyg.py
@@ -1,0 +1,181 @@
+"""
+HSN rewritten with pytorch geometric, can operate on batched hypergraphs. 
+the data is stored in the format of pytorch geometric.
+see https://github.com/pyg-team/pytorch_geometric/blob/cf24b4bcb4e825537ba08d8fc5f31073e2cd84c7/torch_geometric/data/hypergraph_data.py
+for example: 
+    hyperedge_index = torch.tensor([
+        [0, 1, 2, 1, 2, 3],
+        [0, 0, 0, 1, 1, 1],
+    ])
+    hyperedge_weight = torch.tensor([1, 1], dtype=torch.float)
+
+modified from https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/conv/hypergraph_conv.html#HypergraphConv
+"""
+import dhg 
+import torch
+import torch.nn as nn
+from typing import Tuple, Optional
+from einops import rearrange
+from torch.nn import Linear 
+from torch_geometric.nn.pool import global_mean_pool 
+from torch_geometric.nn import GCNConv 
+from torch_geometric.nn.norm import BatchNorm
+from torch_geometric.nn.conv import MessagePassing
+from .hyper_scattering_net import LazyLayer
+from torch_geometric.utils import scatter, softmax
+
+class HGDiffsion(MessagePassing):
+    def __init__(
+            self, 
+            in_channels: int,
+            out_channels: int,
+            trainable_laziness=False,
+            fixed_weights=True,
+            normalize="right",
+            **kwargs,
+    ):
+        kwargs.setdefault('aggr', 'add')
+        super().__init__(flow='source_to_target', node_dim=0, **kwargs)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.trainable_laziness = trainable_laziness
+        self.fixed_weights = fixed_weights
+        assert normalize in ["right", "left", "symmetric"], f"normalize must be one of 'right', 'left', or 'symmetric', not {self.normalize}"
+
+        self.normalize = normalize
+ 
+        # in the future, we could make this time independent, but spatially dependent, as in GRAND
+        if trainable_laziness:
+            self.lazy_layer = LazyLayer(in_channels)
+        # in the future, I'd like to have different weights based on the hypergraph edge size
+        if not self.fixed_weights:
+            self.lin_self = torch.nn.Linear(in_channels, out_channels)
+            self.lin_neigh = torch.nn.Linear(in_channels, out_channels)
+    
+    def forward(self, x: torch.Tensor, hyperedge_index: torch.Tensor,
+                hyperedge_weight: Optional[torch.Tensor] = None,
+                hyperedge_attr: Optional[torch.Tensor] = None,
+                num_edges: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+        
+        num_nodes = x.size(0)
+
+        if num_edges is None:
+            num_edges = 0
+            if hyperedge_index.numel() > 0:
+                num_edges = int(hyperedge_index[1].max()) + 1
+
+        if hyperedge_weight is None:
+            hyperedge_weight = x.new_ones(num_edges)
+        
+        # this is the degree of the vertices (taken inverse)
+        D_v_inv = scatter(hyperedge_weight[hyperedge_index[1]], hyperedge_index[0],
+                    dim=0, dim_size=num_nodes, reduce='sum')
+        D_v_inv = 1.0 / D_v_inv
+        D_v_inv[D_v_inv == float("inf")] = 0
+        # this is the degree of the hyperedges (taken inverse)
+        D_he_inv = scatter(x.new_ones(hyperedge_index.size(1)), hyperedge_index[1],
+                    dim=0, dim_size=num_edges, reduce='sum')
+        D_he_inv = 1.0 / D_he_inv
+        D_he_inv[D_he_inv == float("inf")] = 0
+    
+        if self.normalize == "left":
+            out_edge = self.propagate(hyperedge_index, x=x, norm=D_he_inv,
+                                size=(num_nodes, num_edges))
+            out_edge = self.laziness_weight_process_edge(out_edge, hyperedge_attr)
+            out_node = self.propagate(hyperedge_index.flip([0]), x=out_edge, norm=D_v_inv,
+                                size=(num_edges, num_nodes))
+            out_node = self.laziness_weight_process_node(out_node, x)
+        elif self.normalize == "right":
+            out = D_v_inv.view(-1, 1) * x
+            out_edge = self.propagate(hyperedge_index, x=out,
+                                size=(num_nodes, num_edges))
+            out_edge = self.laziness_weight_process_edge(out_edge, hyperedge_attr)
+            out = D_he_inv.view(-1, 1) * out_edge
+            out_node = self.propagate(hyperedge_index.flip([0]), x=out,
+                                size=(num_edges, num_nodes))
+            out_node = self.laziness_weight_process_node(out_node, x)
+        elif self.normalize == "symmetric":
+            D_v_inv_sqrt = D_v_inv.sqrt()
+            out = D_v_inv_sqrt.view(-1, 1) * x
+            out_edge = self.propagate(hyperedge_index, x=out, norm=D_he_inv,
+                                size=(num_nodes, num_edges))
+            out_edge = self.laziness_weight_process_edge(out_edge, hyperedge_attr)
+            out_node = self.propagate(hyperedge_index.flip([0]), x=out_edge, norm=D_v_inv_sqrt,
+                                size=(num_edges, num_nodes))
+            out_node = self.laziness_weight_process_node(out_node, x)
+        else: 
+            raise ValueError(f"normalize must be one of 'right', 'left', or 'symmetric', not {self.normalize}")
+        return out_node, out_edge
+    
+    def message(self, x_j: torch.Tensor, norm_i: Optional[torch.Tensor] = None) -> torch.Tensor:
+        if norm_i is None:
+            out = x_j
+        else:
+            out = norm_i.view(-1, 1) * x_j
+        return out
+    
+    def laziness_weight_process_edge(self, out_edge, hyperedge_attr):
+        if not self.fixed_weights:
+            out_edge = self.lin_neigh(out_edge) 
+            hyperedge_attr = self.lin_self(out_edge)
+        if self.trainable_laziness and hyperedge_attr is not None:
+            out_edge = self.lazy_layer(out_edge, hyperedge_attr)
+        return out_edge
+    
+    def laziness_weight_process_node(self, out_node, x):
+        if not self.fixed_weights:
+            out_node = self.lin_neigh(out_node)
+            x = self.lin_self(x)
+        if self.trainable_laziness:
+            out_node = self.lazy_layer(out_node, x)
+        return out_node
+
+# class HSNBatch(HSN):
+#     def __init__(self, 
+#                  in_channels, 
+#                  hidden_channels, 
+#                  out_channels, 
+#                  trainable_laziness = False, 
+#                  trainable_scales = False, 
+#                  activation = "modulus", 
+#                  fixed_weights=True, 
+#                  layout = ['hsm','hsm'], 
+#                  pooling = 'mean',
+#                  **kwargs):
+        
+#         super().__init__(in_channels, hidden_channels, out_channels, trainable_laziness, trainable_scales, activation, fixed_weights, layout, **kwargs)
+#         self.pooling = pooling
+
+
+#     def forward(self, data):
+#         x, edge_index, edge_attr, y, batch = data.x, data.edge_index, data.edge_attr, data.y, data.batch
+        
+#         NotImplemented
+#     # def forward(self, hg: dhg.Hypergraph,  X: torch.Tensor, Y: torch.Tensor):
+#     #     for il, layer in enumerate(self.layers):
+#     #         if self.layout[il] == 'hsm':
+#     #             X, Y = layer(hg, X, Y)
+#     #         elif self.layout[il] == 'dim_reduction':
+#     #             X = layer(X)
+#     #             Y = layer(Y) 
+#     #         else:
+#     #             X, Y = layer(hg, X, Y)
+#     #     #import pdb; pdb.set_trace()
+#     #     X = self.batch_norm(X)
+#     #     X = self.mlp(X)
+#     #     # X = self.lin1(X)
+#     #     # X = self.act(X)
+#     #     # X = self.lin2(X)
+#     #     # X = self.act(X)
+#     #     # X = self.lin3(X)
+
+#     #     # compute the same process on the edges:
+#     #     Y = self.batch_norm(Y)
+#     #     Y = self.mlp(Y)
+#     #     # Y = self.lin1(Y)
+#     #     # Y = self.act(Y)
+#     #     # Y = self.lin2(Y)
+#     #     # Y = self.act(Y)
+#     #     # Y = self.lin3(Y)
+
+#     #     return X,Y

--- a/hypgs/models/test_hsn_pyg.py
+++ b/hypgs/models/test_hsn_pyg.py
@@ -1,0 +1,52 @@
+#from hypg_scattering.models.hyper_scattering_net import HSN
+import sys
+# fix this later!
+# sys.path.insert(0, '/home/sumry2023_cqx3/hypergraph_scattering')
+sys.path.append('../../')
+from hypgs.models.hyper_scattering_net import HyperDiffusion
+from hypgs.models.hsn_pyg import HGDiffsion
+from hypgs.utils.data import get_HyperGraphData
+import dhg 
+import torch
+import unittest
+
+
+def gen_hypg_deg_dataset(num_v, num_e, num_graphs):
+    hypergraph_dataset = [dhg.random.hypergraph_Gnm(num_v, num_e, method = 'low_order_first') for _ in range(num_graphs)]
+    return hypergraph_dataset
+
+class TestHGDiffsion(unittest.TestCase):
+    def test_vs_HyperDiffusion(self, trainable_laziness = False, fixed_weights=True, test=False):
+        if not test:
+            return
+        num_graphs = 100
+        num_v = 10
+        num_e = 20 
+        # generate graph dataset
+        train_dataset = gen_hypg_deg_dataset(num_v, num_e, num_graphs)
+        hg = train_dataset[0]
+        starting_features = torch.randn(num_v, num_v)
+        signal_features = num_v
+        num_e_hg = hg.num_e 
+        Y = torch.randn(num_e_hg, num_v)
+        hgdata = get_HyperGraphData(hg, starting_features, Y, None)
+        hyd = HyperDiffusion(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights)
+        hyd_pyg = HGDiffsion(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights, normalize='right')
+        if trainable_laziness:
+            hyd_pyg.lazy_layer.weights = hyd.lazy_layer.weights
+        if not fixed_weights:
+            hyd_pyg.lin_neigh = hyd.lin_neigh
+            hyd_pyg.lin_self = hyd.lin_self
+        node_feat, edge_feat = hyd(hg, starting_features, Y)
+        node_feat2, edge_feat2 = hyd_pyg(x=hgdata.x, hyperedge_index=hgdata.edge_index, hyperedge_attr=hgdata.edge_attr)
+        assert torch.isclose(node_feat2, node_feat).all(), "Node features are not equal"
+        assert torch.isclose(edge_feat2, edge_feat).all(), "Edge features are not equal"
+    
+    def test_all(self):
+        self.test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=True, test=True)
+        self.test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=True, test=True)
+        self.test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=False, test=True)
+        self.test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=False, test=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hypgs/models/test_hsn_pyg.py
+++ b/hypgs/models/test_hsn_pyg.py
@@ -4,7 +4,11 @@ import sys
 # sys.path.insert(0, '/home/sumry2023_cqx3/hypergraph_scattering')
 sys.path.append('../../')
 from hypgs.models.hyper_scattering_net import HyperDiffusion
-from hypgs.models.hsn_pyg import HGDiffsion
+from hypgs.models.hsn_pyg import HyperDiffusion as HyperDiffusionPYG
+from hypgs.models.hyper_scattering_net import HyperScatteringModule
+from hypgs.models.hsn_pyg import HyperScatteringModule as HyperScatteringModulePYG
+from hypgs.models.hyper_scattering_net import HSN
+from hypgs.models.hsn_pyg import HSN as HSNPYG
 from hypgs.utils.data import get_HyperGraphData
 import dhg 
 import torch
@@ -15,38 +19,171 @@ def gen_hypg_deg_dataset(num_v, num_e, num_graphs):
     hypergraph_dataset = [dhg.random.hypergraph_Gnm(num_v, num_e, method = 'low_order_first') for _ in range(num_graphs)]
     return hypergraph_dataset
 
-class TestHGDiffsion(unittest.TestCase):
-    def test_vs_HyperDiffusion(self, trainable_laziness = False, fixed_weights=True, test=False):
-        if not test:
-            return
-        num_graphs = 100
-        num_v = 10
-        num_e = 20 
-        # generate graph dataset
-        train_dataset = gen_hypg_deg_dataset(num_v, num_e, num_graphs)
-        hg = train_dataset[0]
-        starting_features = torch.randn(num_v, num_v)
-        signal_features = num_v
-        num_e_hg = hg.num_e 
-        Y = torch.randn(num_e_hg, num_v)
-        hgdata = get_HyperGraphData(hg, starting_features, Y, None)
-        hyd = HyperDiffusion(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights)
-        hyd_pyg = HGDiffsion(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights, normalize='right')
-        if trainable_laziness:
-            hyd_pyg.lazy_layer.weights = hyd.lazy_layer.weights
-        if not fixed_weights:
-            hyd_pyg.lin_neigh = hyd.lin_neigh
-            hyd_pyg.lin_self = hyd.lin_self
-        node_feat, edge_feat = hyd(hg, starting_features, Y)
-        node_feat2, edge_feat2 = hyd_pyg(x=hgdata.x, hyperedge_index=hgdata.edge_index, hyperedge_attr=hgdata.edge_attr)
-        assert torch.isclose(node_feat2, node_feat).all(), "Node features are not equal"
-        assert torch.isclose(edge_feat2, edge_feat).all(), "Edge features are not equal"
-    
-    def test_all(self):
-        self.test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=True, test=True)
-        self.test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=True, test=True)
-        self.test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=False, test=True)
-        self.test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=False, test=True)
+class TestHSNPYG(unittest.TestCase):
+    def testHyperDiffusion(self):
+        test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=True)
+        test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=True)
+        test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=False)
+        test_vs_HyperDiffusion(trainable_laziness = True, fixed_weights=False)
+
+    def testHyperScatteringModule(self):
+        trainable_laziness_values = [False, True]
+        trainable_scales_values = [False, True]
+        activation_values = ["blis", "leaky_relu", 'modulus', None]
+        fixed_weights_values = [True, False]
+
+        for trainable_laziness in trainable_laziness_values:
+            for trainable_scales in trainable_scales_values:
+                for activation in activation_values:
+                    for fixed_weights in fixed_weights_values:
+                        test_vs_HyperScatteringModule(trainable_laziness, trainable_scales, activation, fixed_weights)
+
+
+    # Test cases for HSN
+    # def test_hsn(self):
+    #     trainable_laziness_values = [False, True]
+    #     trainable_scales_values = [False, True]
+    #     activation_values = ["blis", "leaky_relu", 'modulus', None]
+    #     fixed_weights_values = [True, False]
+    #     layout_values = [['hsm', 'hsm'], ['hsm', 'dim_reduction'], ['dim_reduction', 'dim_reduction']]
+
+    #     for trainable_laziness in trainable_laziness_values:
+    #         for trainable_scales in trainable_scales_values:
+    #             for activation in activation_values:
+    #                 for fixed_weights in fixed_weights_values:
+    #                     for layout in layout_values:
+    #                         layout_str = '_'.join(layout)
+    #                         test_name = f"test_hsn_{trainable_laziness}_{trainable_scales}_{activation}_{fixed_weights}_{layout_str}"
+    #                         test_method = lambda self: self.test_vs_HSN(
+    #                             trainable_laziness, trainable_scales, activation, fixed_weights, layout)
+    #                         setattr(TestHSNPYG, test_name, test_method)
+    # def testHSN(self):
+    #     trainable_laziness_values = [False, True]
+    #     trainable_scales_values = [False, True]
+    #     activation_values = ["blis", "leaky_relu", 'modulus', None]
+    #     fixed_weights_values = [True, False]
+    #     layout_values = [['hsm', 'hsm'], ['hsm', 'dim_reduction'], ['dim_reduction', 'dim_reduction']]
+    #     for trainable_laziness in trainable_laziness_values:
+    #         for trainable_scales in trainable_scales_values:
+    #             for activation in activation_values:
+    #                 for fixed_weights in fixed_weights_values:
+    #                     for layout in layout_values:
+    #                         test_vs_HSN(trainable_laziness, trainable_scales, activation, fixed_weights, layout)
+
+
+def generate_test_cases():
+    trainable_laziness_values = [False, True]
+    trainable_scales_values = [False, True]
+    activation_values = ["blis", "leaky_relu", 'modulus', None]
+    fixed_weights_values = [True, False]
+    layout_values = [['hsm', 'hsm'], ['hsm', 'dim_reduction'], ['dim_reduction', 'dim_reduction']]
+
+    for trainable_laziness in trainable_laziness_values:
+        for trainable_scales in trainable_scales_values:
+            for activation in activation_values:
+                for fixed_weights in fixed_weights_values:
+                    for layout in layout_values:
+                        layout_str = '_'.join(layout)
+                        test_name = f"test_hsn_{trainable_laziness}_{trainable_scales}_{activation}_{fixed_weights}_{layout_str}"
+                        test_method = lambda self: test_vs_HSN(
+                            trainable_laziness, trainable_scales, activation, fixed_weights, layout)
+                        setattr(TestHSNPYG, test_name, test_method)
+
+def get_test_data():
+    num_graphs = 100
+    num_v = 10
+    num_e = 20 
+    # generate graph dataset
+    train_dataset = gen_hypg_deg_dataset(num_v, num_e, num_graphs)
+    hg = train_dataset[0]
+    starting_features = torch.randn(num_v, num_v)
+    signal_features = num_v
+    num_e_hg = hg.num_e 
+    Y = torch.randn(num_e_hg, num_v)
+    hgdata = get_HyperGraphData(hg, starting_features, Y, None)
+    return signal_features, hg, starting_features, Y, hgdata
+
+def test_vs_HyperDiffusion(trainable_laziness = False, fixed_weights=True):
+    signal_features, hg, starting_features, Y, hgdata = get_test_data()
+    hyd = HyperDiffusion(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights)
+    hyd_pyg = HyperDiffusionPYG(in_channels=signal_features, out_channels=signal_features, trainable_laziness=trainable_laziness, fixed_weights=fixed_weights, normalize='right')
+    if trainable_laziness:
+        hyd_pyg.lazy_layer.weights = hyd.lazy_layer.weights
+    if not fixed_weights:
+        hyd_pyg.lin_neigh = hyd.lin_neigh
+        hyd_pyg.lin_self = hyd.lin_self
+    node_feat, edge_feat = hyd(hg, starting_features, Y)
+    node_feat2, edge_feat2 = hyd_pyg(x=hgdata.x, hyperedge_index=hgdata.edge_index, hyperedge_attr=hgdata.edge_attr)
+    assert torch.isclose(node_feat2, node_feat).all(), "Node features are not equal"
+    assert torch.isclose(edge_feat2, edge_feat).all(), "Edge features are not equal"
+
+def test_vs_HyperScatteringModule(trainable_laziness = False, trainable_scales = False, activation = "blis", fixed_weights=True):
+    signal_features, hg, starting_features, Y, hgdata = get_test_data()
+    hsm = HyperScatteringModule(in_channels=signal_features, trainable_laziness = trainable_laziness, trainable_scales = trainable_scales, activation = activation, fixed_weights=fixed_weights)
+    hsm_pyg = HyperScatteringModulePYG(in_channels=signal_features, trainable_laziness = trainable_laziness, trainable_scales = trainable_scales, activation = activation, fixed_weights=fixed_weights, normalize="right")
+    if trainable_laziness:
+        hsm_pyg.diffusion_layer1.lazy_layer.weights = hsm.diffusion_layer1.lazy_layer.weights
+    if not fixed_weights:
+        hsm_pyg.diffusion_layer1.lin_neigh = hsm.diffusion_layer1.lin_neigh
+        hsm_pyg.diffusion_layer1.lin_self = hsm.diffusion_layer1.lin_self
+    s_nodes, s_edges = hsm(hg, starting_features, Y)
+    s_nodes2, s_edges2 = hsm_pyg(x=hgdata.x, hyperedge_index=hgdata.edge_index, hyperedge_attr=hgdata.edge_attr)
+    assert torch.isclose(s_nodes, s_nodes2).all()
+    assert torch.isclose(s_edges, s_edges2).all()
+
+def test_vs_HSN(
+        trainable_laziness = False, 
+        trainable_scales = False, 
+        activation = "modulus", 
+        fixed_weights=True, 
+        layout = ['hsm','hsm'], 
+        normalize="right",
+        device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"),
+        **kwargs
+    ):
+    signal_features, hg, starting_features, Y, hgdata = get_test_data()
+    hsn = HSN(in_channels=signal_features, 
+              hidden_channels=8,
+              out_channels = 5, 
+              trainable_laziness = trainable_laziness,
+              trainable_scales = trainable_scales, 
+              activation = activation, 
+              fixed_weights=fixed_weights, 
+              layout=layout, 
+              normalize=normalize, 
+              device=device, 
+              **kwargs)
+    hsn_pyg = HSNPYG(in_channels=signal_features, 
+              hidden_channels=8,
+              out_channels = 5, 
+              trainable_laziness = trainable_laziness,
+              trainable_scales = trainable_scales, 
+              activation = activation, 
+              fixed_weights=fixed_weights, 
+              layout=layout, 
+              normalize=normalize, 
+              device=device, 
+              **kwargs)
+    for i, layout in enumerate(hsn.layout):
+        if layout == 'hsm':
+            if trainable_laziness:
+                hsn_pyg.layers[i].diffusion_layer1.lazy_layer.weights = hsn.layers[i].diffusion_layer1.lazy_layer.weights
+            if not fixed_weights:
+                hsn_pyg.layers[i].diffusion_layer1.lin_neigh = hsn.layers[i].diffusion_layer1.lin_neigh
+                hsn_pyg.layers[i].diffusion_layer1.lin_self = hsn.layers[i].diffusion_layer1.lin_self
+        elif layout == 'dim_reduction':
+            hsn_pyg.layers[i] = hsn.layers[i]
+        else:
+            raise ValueError(f"Unknown layout {layout}")
+    hsn_pyg.batch_norm = hsn.batch_norm
+    hsn_pyg.mlp = hsn.mlp
+
+    x, hyperedge_attr = hsn(hg, starting_features, Y)
+    x2, hyperedge_attr2 = hsn_pyg(x=hgdata.x, hyperedge_index=hgdata.edge_index, hyperedge_attr=hgdata.edge_attr)
+    assert torch.isclose(x, x2).all()
+    assert torch.isclose(hyperedge_attr, hyperedge_attr2).all()
+
+generate_test_cases()
 
 if __name__ == '__main__':
     unittest.main()

--- a/hypgs/utils/data.py
+++ b/hypgs/utils/data.py
@@ -1,0 +1,65 @@
+"""
+Helper for using dataset and dataloader in pytorch geometric.
+see https://github.com/pyg-team/pytorch_geometric/blob/cf24b4bcb4e825537ba08d8fc5f31073e2cd84c7/torch_geometric/data/hypergraph_data.py
+"""
+import torch
+from torch_geometric.data.hypergraph_data import HyperGraphData
+from dhg import Graph, Hypergraph
+
+def get_hyperedge_index(HG):
+    """
+    Get the hyperedge index from a hypergraph object. for the HyperGraphData class.
+    
+    Args:
+        HG: Hypergraph object
+    """
+    hyperedge_list = HG.e[0]
+    # Flatten the list of tuples and also create a corresponding index list
+    flattened_list = []
+    index_list = []
+    for i, t in enumerate(hyperedge_list):
+        flattened_list.extend(t)
+        index_list.extend([i] * len(t))
+
+    # Convert to 2D numpy array
+    hyperedge_index = torch.tensor([flattened_list, index_list])
+
+    return hyperedge_index
+
+def get_HyperGraphData(HG, node_features, hyperedge_attr, labels):
+    """
+    Get the HyperGraphData class from a hypergraph object and the corresponding node features, hyperedge attributes and labels.
+    
+    Args:
+        HG: Hypergraph object
+        node_features (torch.Tensor, optional): Node feature matrix with shape
+            :obj:`[num_nodes, num_node_features]`. (default: :obj:`None`)
+        hyperedge_attr (torch.Tensor, optional): Edge feature matrix with shape
+            :obj:`[num_edges, num_edge_features]`.
+            (default: :obj:`None`)
+        labels (torch.Tensor, optional): Graph-level or node-level ground-truth
+            labels with arbitrary shape. (default: :obj:`None`)
+    
+    Returns:
+        a HyperGraphData object
+    """
+    hyperedge_index = get_hyperedge_index(HG)
+    return HyperGraphData(x=node_features, edge_index=hyperedge_index, edge_attr=hyperedge_attr, y=labels)
+
+def get_HGDataset(original_dataset, to_hg_func=lambda g: Hypergraph.from_graph_kHop(g, k=1)):
+    hgdataset = []
+    for graph_dat in original_dataset:
+        # Access the first graph
+        # Get the edge list
+        edge_list = graph_dat.edge_index.t()
+        num_vertices = graph_dat.num_nodes
+        # Get node features
+        node_features = graph_dat.x
+        # Get labels
+        labels = graph_dat.y
+        G = Graph(num_vertices, edge_list)
+        HG1 = to_hg_func(G)
+        X, lbl = node_features, labels
+        Y = torch.zeros(HG1.num_e, X.shape[1]) # use all zero hyperedge attributes
+        hgdataset.append(get_HyperGraphData(HG1, X, Y, lbl))
+    return hgdataset

--- a/hypgs/utils/test_data.py
+++ b/hypgs/utils/test_data.py
@@ -1,38 +1,37 @@
 import unittest
-import torch
-import sys
-from data import get_HGDataset
+# from data import get_HGDataset
 from torch_geometric.data import Data
+from torch_geometric.data.hypergraph_data import HyperGraphData
+from dhg import Hypergraph
+import torch
+from data import HGDataset
 
-class TestGetHGDataset(unittest.TestCase):
-    def test_empty_dataset(self):
-        original_dataset = []
-        hgdataset = get_HGDataset(original_dataset)
-        self.assertEqual(len(hgdataset), 0)
+class TestHGDataset(unittest.TestCase):
+    def test_len(self):
+        # Create a dataset with 3 data items
+        edge_index_1 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        num_nodes_1 = 3
+        node_features_1 = torch.tensor([[1, 2], [3, 4], [5, 6]])
+        labels_1 = torch.tensor([0, 1, 0])
+        graph_dat_1 = Data(edge_index=edge_index_1, num_nodes=num_nodes_1, x=node_features_1, y=labels_1)
+        edge_index_2 = torch.tensor([[0, 1], [1, 0]])
+        num_nodes_2 = 2
+        node_features_2 = torch.tensor([[7, 8], [9, 10]])
+        labels_2 = torch.tensor([1, 0])
+        graph_dat_2 = Data(edge_index=edge_index_2, num_nodes=num_nodes_2, x=node_features_2, y=labels_2)
+        edge_index_3 = torch.tensor([[0, 1], [1, 0]])
+        num_nodes_3 = 2
+        node_features_3 = torch.tensor([[11, 12], [13, 14]])
+        labels_3 = torch.tensor([0, 1])
+        graph_dat_3 = Data(edge_index=edge_index_3, num_nodes=num_nodes_3, x=node_features_3, y=labels_3)
 
-    def test_single_graph(self):
+        original_dataset = [graph_dat_1, graph_dat_2, graph_dat_3]
 
-        edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
-        num_nodes = 3
-        node_features = torch.tensor([[1, 2], [3, 4], [5, 6]])
-        labels = torch.tensor([0, 1, 0])
-        graph_dat = Data(edge_index=edge_index, num_nodes=num_nodes, x=node_features, y=labels)
-        original_dataset = [graph_dat]
+        dataset = HGDataset(original_dataset)
+        self.assertEqual(len(dataset), 3)
 
-        # Call the function
-        hgdataset = get_HGDataset(original_dataset)
-
-        # Check the result
-        self.assertEqual(len(hgdataset), 1)
-        self.assertEqual(hgdataset[0].num_nodes, num_nodes)
-        self.assertEqual(hgdataset[0].num_edges, 3)
-        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features)))
-        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features)))
-        self.assertTrue(torch.all(torch.eq(hgdataset[0].y, labels)))
-
-    def test_multiple_graphs(self):
-
-        # Create multiple graph dataset
+    def test_get(self):
+        # Create a dataset with 2 data items
         edge_index_1 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
         num_nodes_1 = 3
         node_features_1 = torch.tensor([[1, 2], [3, 4], [5, 6]])
@@ -46,20 +45,52 @@ class TestGetHGDataset(unittest.TestCase):
 
         original_dataset = [graph_dat_1, graph_dat_2]
 
-        # Call the function
-        hgdataset = get_HGDataset(original_dataset)
+        dataset = HGDataset(original_dataset)
 
-        # Check the result
-        self.assertEqual(len(hgdataset), 2)
-        self.assertEqual(hgdataset[0].num_nodes, num_nodes_1)
-        self.assertEqual(hgdataset[0].num_edges, 3)
-        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features_1)))
-        self.assertTrue(torch.all(torch.eq(hgdataset[0].y, labels_1)))
+        # Get the first data item
+        data = dataset.get(0)
 
-        self.assertEqual(hgdataset[1].num_nodes, num_nodes_2)
-        self.assertEqual(hgdataset[1].num_edges, 1)
-        self.assertTrue(torch.all(torch.eq(hgdataset[1].x, node_features_2)))
-        self.assertTrue(torch.all(torch.eq(hgdataset[1].y, labels_2)))
+        # Check if the returned data item is of type Data
+        self.assertIsInstance(data, Data)
+
+    def test_to_hg_func_default(self):
+        # Create a dataset with 1 data item
+        edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        num_nodes = 3
+        node_features = torch.tensor([[1, 2], [3, 4], [5, 6]])
+        labels = torch.tensor([0, 1, 0])
+        graph_dat = Data(edge_index=edge_index, num_nodes=num_nodes, x=node_features, y=labels)
+        original_dataset = [graph_dat]
+
+        # Create a dataset using the default to_hg_func
+        dataset = HGDataset(original_dataset)
+
+        # Get the first data item
+        data = dataset.get(0)
+
+        # Check if the data item has been converted to a hypergraph
+        self.assertIsInstance(data, HyperGraphData)
+
+    def test_to_hg_func_custom(self):
+        # Define a custom to_hg_func
+        custom_to_hg_func = lambda g: Hypergraph.from_graph_kHop(g, k=2)
+
+        # Create a dataset with 1 data item
+        edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        num_nodes = 3
+        node_features = torch.tensor([[1, 2], [3, 4], [5, 6]])
+        labels = torch.tensor([0, 1, 0])
+        graph_dat = Data(edge_index=edge_index, num_nodes=num_nodes, x=node_features, y=labels)
+        original_dataset = [graph_dat]
+
+        # Create a dataset using the custom to_hg_func
+        dataset = HGDataset(original_dataset, to_hg_func=custom_to_hg_func)
+
+        # Get the first data item
+        data = dataset.get(0)
+
+        # Check if the data item has been converted to a hypergraph using the custom logic
+        self.assertIsInstance(data, HyperGraphData)
 
 if __name__ == '__main__':
     unittest.main()

--- a/hypgs/utils/test_data.py
+++ b/hypgs/utils/test_data.py
@@ -1,0 +1,65 @@
+import unittest
+import torch
+import sys
+from data import get_HGDataset
+from torch_geometric.data import Data
+
+class TestGetHGDataset(unittest.TestCase):
+    def test_empty_dataset(self):
+        original_dataset = []
+        hgdataset = get_HGDataset(original_dataset)
+        self.assertEqual(len(hgdataset), 0)
+
+    def test_single_graph(self):
+
+        edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        num_nodes = 3
+        node_features = torch.tensor([[1, 2], [3, 4], [5, 6]])
+        labels = torch.tensor([0, 1, 0])
+        graph_dat = Data(edge_index=edge_index, num_nodes=num_nodes, x=node_features, y=labels)
+        original_dataset = [graph_dat]
+
+        # Call the function
+        hgdataset = get_HGDataset(original_dataset)
+
+        # Check the result
+        self.assertEqual(len(hgdataset), 1)
+        self.assertEqual(hgdataset[0].num_nodes, num_nodes)
+        self.assertEqual(hgdataset[0].num_edges, 3)
+        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features)))
+        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features)))
+        self.assertTrue(torch.all(torch.eq(hgdataset[0].y, labels)))
+
+    def test_multiple_graphs(self):
+
+        # Create multiple graph dataset
+        edge_index_1 = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+        num_nodes_1 = 3
+        node_features_1 = torch.tensor([[1, 2], [3, 4], [5, 6]])
+        labels_1 = torch.tensor([0, 1, 0])
+        graph_dat_1 = Data(edge_index=edge_index_1, num_nodes=num_nodes_1, x=node_features_1, y=labels_1)
+        edge_index_2 = torch.tensor([[0, 1], [1, 0]])
+        num_nodes_2 = 2
+        node_features_2 = torch.tensor([[7, 8], [9, 10]])
+        labels_2 = torch.tensor([1, 0])
+        graph_dat_2 = Data(edge_index=edge_index_2, num_nodes=num_nodes_2, x=node_features_2, y=labels_2)
+
+        original_dataset = [graph_dat_1, graph_dat_2]
+
+        # Call the function
+        hgdataset = get_HGDataset(original_dataset)
+
+        # Check the result
+        self.assertEqual(len(hgdataset), 2)
+        self.assertEqual(hgdataset[0].num_nodes, num_nodes_1)
+        self.assertEqual(hgdataset[0].num_edges, 3)
+        self.assertTrue(torch.all(torch.eq(hgdataset[0].x, node_features_1)))
+        self.assertTrue(torch.all(torch.eq(hgdataset[0].y, labels_1)))
+
+        self.assertEqual(hgdataset[1].num_nodes, num_nodes_2)
+        self.assertEqual(hgdataset[1].num_edges, 1)
+        self.assertTrue(torch.all(torch.eq(hgdataset[1].x, node_features_2)))
+        self.assertTrue(torch.all(torch.eq(hgdataset[1].y, labels_2)))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reimplemented hypergraph data, HyperDiffusion, HyperScatteringModule, HSN with pyg,  
now can support batching of pyg with an anticipated performance boost and graph-level pooling  
I have tested that this code gives exactly the same output as the code with dhg.  
there are some changes of API to be compatible with pyg data.  

*need to update to the latest  version (2.4) of pyg*

still need to be implemented:  
1. add pooling functionality to HSN (with batch support)
2. write a training logic that takes in a pyg dataloader (with this hypergraph dataset)

this code is now not so dependent on dhg (only using dhg to get k-hop hypergraph from graph)  
compatibility of pyg allows for all the tools in pyg such as pooling.